### PR TITLE
Code smell cleanup - use constants

### DIFF
--- a/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateOptionsPane.java
+++ b/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateOptionsPane.java
@@ -53,9 +53,9 @@ class RotateOptionsPane extends HBox
     private static final String ANGLE_ID = "rotation";
     private static final String PAGES_ID = "rotationType";
 
-    public String getPagesId() {return this.PAGES_ID;}
+    public static String getPagesId() {return PAGES_ID;}
 
-    public String getAngleId() {return this.ANGLE_ID;}
+    public static String getAngleId() {return ANGLE_ID;}
 
     RotateOptionsPane() {
         super(Style.DEFAULT_SPACING);

--- a/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateOptionsPane.java
+++ b/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateOptionsPane.java
@@ -50,6 +50,12 @@ class RotateOptionsPane extends HBox
 
     private ComboBox<KeyStringValueItem<PredefinedSetOfPages>> rotationType = new ComboBox<>();
     private ComboBox<KeyStringValueItem<Rotation>> rotation = new ComboBox<>();
+    private static final String ANGLE_ID = "rotation";
+    private static final String PAGES_ID = "rotationType";
+
+    public String getPagesId() {return this.PAGES_ID;}
+
+    public String getAngleId() {return this.ANGLE_ID;}
 
     RotateOptionsPane() {
         super(Style.DEFAULT_SPACING);
@@ -59,7 +65,7 @@ class RotateOptionsPane extends HBox
                 .add(keyValue(PredefinedSetOfPages.EVEN_PAGES, DefaultI18nContext.getInstance().i18n("Even pages")));
         this.rotationType.getItems()
                 .add(keyValue(PredefinedSetOfPages.ODD_PAGES, DefaultI18nContext.getInstance().i18n("Odd pages")));
-        this.rotationType.setId("rotationType");
+        this.rotationType.setId(PAGES_ID);
 
         this.rotation.getItems()
                 .add(keyValue(Rotation.DEGREES_90, DefaultI18nContext.getInstance().i18n("90 degrees clockwise")));
@@ -67,7 +73,7 @@ class RotateOptionsPane extends HBox
                 .add(keyValue(Rotation.DEGREES_180, DefaultI18nContext.getInstance().i18n("180 degrees clockwise")));
         this.rotation.getItems().add(
                 keyValue(Rotation.DEGREES_270, DefaultI18nContext.getInstance().i18n("90 degrees counterclockwise")));
-        this.rotation.setId("rotation");
+        this.rotation.setId(ANGLE_ID);
 
         getStyleClass().addAll(Style.HCONTAINER.css());
         getStyleClass().addAll(Style.CONTAINER.css());
@@ -90,17 +96,17 @@ class RotateOptionsPane extends HBox
 
     @Override
     public void saveStateTo(Map<String, String> data) {
-        data.put("rotation", Optional.ofNullable(rotation.getSelectionModel().getSelectedItem())
+        data.put(ANGLE_ID, Optional.ofNullable(rotation.getSelectionModel().getSelectedItem())
                 .map(i -> i.getKey().toString()).orElse(EMPTY));
-        data.put("rotationType", Optional.ofNullable(rotationType.getSelectionModel().getSelectedItem())
+        data.put(PAGES_ID, Optional.ofNullable(rotationType.getSelectionModel().getSelectedItem())
                 .map(i -> i.getKey().toString()).orElse(EMPTY));
     }
 
     @Override
     public void restoreStateFrom(Map<String, String> data) {
-        Optional.ofNullable(data.get("rotation")).map(Rotation::valueOf).map(r -> keyEmptyValue(r))
+        Optional.ofNullable(data.get(ANGLE_ID)).map(Rotation::valueOf).map(r -> keyEmptyValue(r))
                 .ifPresent(r -> this.rotation.getSelectionModel().select(r));
-        Optional.ofNullable(data.get("rotationType")).map(PredefinedSetOfPages::valueOf).map(r -> keyEmptyValue(r))
+        Optional.ofNullable(data.get(PAGES_ID)).map(PredefinedSetOfPages::valueOf).map(r -> keyEmptyValue(r))
                 .ifPresent(r -> this.rotationType.getSelectionModel().select(r));
     }
 }

--- a/pdfsam-rotate/src/test/java/org/pdfsam/rotate/RotateOptionsPaneTest.java
+++ b/pdfsam-rotate/src/test/java/org/pdfsam/rotate/RotateOptionsPaneTest.java
@@ -74,8 +74,8 @@ public class RotateOptionsPaneTest extends ApplicationTest {
     public void onSaveWorkspace() {
         Map<String, String> data = new HashMap<>();
         victim.saveStateTo(data);
-        assertEquals(Rotation.DEGREES_90.toString(), data.get("rotation"));
-        assertEquals(PredefinedSetOfPages.ALL_PAGES.toString(), data.get("rotationType"));
+        assertEquals(Rotation.DEGREES_90.toString(), data.get(victim.getAngleId()));
+        assertEquals(PredefinedSetOfPages.ALL_PAGES.toString(), data.get(victim.getPagesId()));
     }
 
     @Test
@@ -83,8 +83,8 @@ public class RotateOptionsPaneTest extends ApplicationTest {
         ComboBox<KeyStringValueItem<PredefinedSetOfPages>> rotationType = lookup("#rotationType").queryComboBox();
         ComboBox<KeyStringValueItem<Rotation>> rotation = lookup("#rotation").queryComboBox();
         Map<String, String> data = new HashMap<>();
-        data.put("rotation", Rotation.DEGREES_270.toString());
-        data.put("rotationType", PredefinedSetOfPages.EVEN_PAGES.toString());
+        data.put(victim.getAngleId(), Rotation.DEGREES_270.toString());
+        data.put(victim.getPagesId(), PredefinedSetOfPages.EVEN_PAGES.toString());
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(Rotation.DEGREES_270, rotation.getSelectionModel().getSelectedItem().getKey());
         assertEquals(PredefinedSetOfPages.EVEN_PAGES, rotationType.getSelectionModel().getSelectedItem().getKey());
@@ -95,8 +95,8 @@ public class RotateOptionsPaneTest extends ApplicationTest {
         ComboBox<KeyStringValueItem<PredefinedSetOfPages>> rotationType = lookup("#rotationType").queryComboBox();
         ComboBox<KeyStringValueItem<Rotation>> rotation = lookup("#rotation").queryComboBox();
         Map<String, String> data = new HashMap<>();
-        data.put("rotation", Rotation.DEGREES_270.toString());
-        data.put("rotationType", PredefinedSetOfPages.EVEN_PAGES.toString());
+        data.put(victim.getAngleId(), Rotation.DEGREES_270.toString());
+        data.put(victim.getPagesId(), PredefinedSetOfPages.EVEN_PAGES.toString());
         WaitForAsyncUtils.waitForAsyncFx(2000, () -> victim.restoreStateFrom(data));
         assertEquals(Rotation.DEGREES_270, rotation.getSelectionModel().getSelectedItem().getKey());
         assertEquals(PredefinedSetOfPages.EVEN_PAGES, rotationType.getSelectionModel().getSelectedItem().getKey());


### PR DESCRIPTION
This update creates two constants in the Rotate module to replace several places where code contained hard coded string values. The constants were made static variables and static getter routines were provided to access these constants. JUnit tests were updated to use these new getter routines.