### PR TITLE
Code smell cleanup (long Method )+ tests 

### DIFF
--- a/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateParametersBuilder.java
+++ b/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateParametersBuilder.java
@@ -69,30 +69,38 @@ class RotateParametersBuilder extends AbstractPdfOutputParametersBuilder<BulkRot
         else {
             //only need to alter and flatten page ranges if EVEN or ODD pages are specified
             //This routine will alter 3-10 to 3,5,7,9 if ODD pages are selected
-            boolean even = evenOddAll.name().equals("EVEN_PAGES");
-            Set<PageRange> filteredPages = new HashSet<PageRange>();
+            return filteredPaged(pageSelection, evenOddAll, lastPage);
+        }
+    }
 
-            Iterator<PageRange> it = pageSelection.iterator();
-            while (it.hasNext()) {
-                PageRange range = it.next();
-                if (range.getEnd() != range.getStart()) {
-                    int startPage = range.getStart();
-                    //if range is specified as "7-", set the endPage to the last page of document
-                    int endPage = (lastPage < range.getEnd()) ? lastPage : range.getEnd();
-                    for (int number = startPage; number <= endPage; number++) {
-                        //only add even or odd numbers back into page collection depending on which the user selected
-                        if (((number % 2) == 0 && even) ||
-                                ((number % 2) == 1 && !even)) {
-                            filteredPages.add(new PageRange(number, number));
-                        }
-                    }
-                }
-                else {
-                    //only a single page not a range of pages
-                    filteredPages.add(range);
+    private Set<PageRange> filteredPaged(Set<PageRange> pageSelection, PredefinedSetOfPages evenOddAll, Integer lastPage) {
+        boolean even = evenOddAll.name().equals("EVEN_PAGES");
+        Set<PageRange> filteredPages = new HashSet<PageRange>();
+
+        Iterator<PageRange> it = pageSelection.iterator();
+        while (it.hasNext()) {
+            extractPageRange(lastPage, even, filteredPages, it);
+        }
+        return filteredPages;
+    }
+
+    private void extractPageRange(Integer lastPage, boolean even, Set<PageRange> filteredPages, Iterator<PageRange> it) {
+        PageRange range = it.next();
+        if (range.getEnd() != range.getStart()) {
+            int startPage = range.getStart();
+            //if range is specified as "7-", set the endPage to the last page of document
+            int endPage = (lastPage < range.getEnd()) ? lastPage : range.getEnd();
+            for (int number = startPage; number <= endPage; number++) {
+                //only add even or odd numbers back into page collection depending on which the user selected
+                if (((number % 2) == 0 && even) ||
+                        ((number % 2) == 1 && !even)) {
+                    filteredPages.add(new PageRange(number, number));
                 }
             }
-            return filteredPages;
+        }
+        else {
+            //only a single page not a range of pages
+            filteredPages.add(range);
         }
     }
 

--- a/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateParametersBuilder.java
+++ b/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateParametersBuilder.java
@@ -79,13 +79,13 @@ class RotateParametersBuilder extends AbstractPdfOutputParametersBuilder<BulkRot
 
         Iterator<PageRange> it = pageSelection.iterator();
         while (it.hasNext()) {
-            extractPageRange(lastPage, even, filteredPages, it);
+            PageRange range = it.next();
+            extractPageRange(lastPage, even, filteredPages, range);
         }
         return filteredPages;
     }
 
-    private void extractPageRange(Integer lastPage, boolean even, Set<PageRange> filteredPages, Iterator<PageRange> it) {
-        PageRange range = it.next();
+    private void extractPageRange(Integer lastPage, boolean even, Set<PageRange> filteredPages, PageRange range) {
         if (range.getEnd() != range.getStart()) {
             int startPage = range.getStart();
             //if range is specified as "7-", set the endPage to the last page of document

--- a/pdfsam-rotate/src/test/java/org/pdfsam/rotate/RotateParametersBuilderTest.java
+++ b/pdfsam-rotate/src/test/java/org/pdfsam/rotate/RotateParametersBuilderTest.java
@@ -49,6 +49,7 @@ public class RotateParametersBuilderTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
     private RotateParametersBuilder victim;
+//    private PredefinedSetOfPages predefinedSetOfPages;
 
     @Before
     public void setUp() {
@@ -114,5 +115,43 @@ public class RotateParametersBuilderTest {
         BulkRotateParameters params = victim.build();
         Set<PdfRotationInput> inputs = params.getInputSet();
         assertEquals(2, inputs.size());
+    }
+
+    /** Rotate All Pages*/
+    @Test
+    public void filterEvenOddPages() throws Exception{
+        victim.rotationType(PredefinedSetOfPages.ALL_PAGES);
+        FileOrDirectoryTaskOutput output = mock(FileOrDirectoryTaskOutput.class);
+        victim.output(output);
+        File file = folder.newFile("my.pdf");
+        PdfFileSource source = PdfFileSource.newInstanceNoPassword(file);
+        // added new parameter for ps3 change request
+        victim.addInput(source, null, 5);
+        victim.version(PdfVersion.VERSION_1_7);
+        BulkRotateParameters params = victim.build();
+        Set<PdfRotationInput> inputs = params.getInputSet();
+        PdfRotationInput input = inputs.iterator().next();
+
+        /** Rotate All Pages*/
+        assertEquals(5, input.getPages(5).size());
+    }
+
+    /** Rotate Even Pages*/
+    @Test
+    public void filterEvenPages() throws Exception{
+        victim.rotationType(PredefinedSetOfPages.EVEN_PAGES);
+        FileOrDirectoryTaskOutput output = mock(FileOrDirectoryTaskOutput.class);
+        victim.output(output);
+        File file = folder.newFile("my.pdf");
+        PdfFileSource source = PdfFileSource.newInstanceNoPassword(file);
+        // added new parameter for ps3 change request
+        victim.addInput(source, null, 10);
+        victim.version(PdfVersion.VERSION_1_7);
+        BulkRotateParameters params = victim.build();
+        Set<PdfRotationInput> inputs = params.getInputSet();
+        PdfRotationInput input = inputs.iterator().next();
+
+        /** Rotate Even Pages*/
+        assertEquals(5, input.getPages(10).size());
     }
 }


### PR DESCRIPTION
I split filterEvenOddPages  method to  sub methods (i.e. filteredPaged and extractPageRange) to reduce the cognitive complexity and make the method shorter. The cognitive complexity was at first 24 (max allowed is 15) and after refactoring the code smell is gone and the complexity reduce to less than 10. 